### PR TITLE
Allow overriding the creation of SourceViewerConfiguration

### DIFF
--- a/org.dadacoalition.yedit/src/org/dadacoalition/yedit/editor/YEdit.java
+++ b/org.dadacoalition.yedit/src/org/dadacoalition/yedit/editor/YEdit.java
@@ -78,6 +78,13 @@ public class YEdit extends TextEditor {
 	protected void initializeEditor() {
 		super.initializeEditor();
 		
+		YEditSourceViewerConfiguration jsvc = createSourceViewerConfiguration();
+		
+		setSourceViewerConfiguration(jsvc);
+		sourceViewerConfig = jsvc;
+	}
+
+	protected YEditSourceViewerConfiguration createSourceViewerConfiguration() {
 		YEditSourceViewerConfiguration jsvc = null;
 		
 		/*
@@ -103,9 +110,7 @@ public class YEdit extends TextEditor {
 		if( !contribFound ) {
 			jsvc = new YEditSourceViewerConfiguration();
 		}
-		
-		setSourceViewerConfiguration(jsvc);
-		sourceViewerConfig = jsvc;
+		return jsvc;
 	}
 
 	public void createPartControl(Composite parent) {


### PR DESCRIPTION
While it is possible to use the extension point to change SourceViewerConfiguration this only really works for a use case where you want to change source-viewer configuration indiscriminately for any YEdit editor.

If on the other hand one wants to create a 'customized' YEdit subclass and define it as a new editor to use only for some .yml files (defined by a new contentType) then the extension point doesn't work (you only want to change SourceViewerConfiguration in your own subclass, not all YEdit instances).

This change pulls-out the creation of SourceViewerConfiguration into a a protected factory method which can easily be overriden.