### PR TITLE
Bug: save fails when outline closed

### DIFF
--- a/org.dadacoalition.yedit/src/org/dadacoalition/yedit/editor/YAMLContentOutlinePage.java
+++ b/org.dadacoalition.yedit/src/org/dadacoalition/yedit/editor/YAMLContentOutlinePage.java
@@ -197,7 +197,7 @@ public class YAMLContentOutlinePage extends ContentOutlinePage {
 	public void update(){	    
 		TreeViewer viewer= getTreeViewer();
 
-		if (viewer != null) {
+		if (viewer != null && viewer.getControl()!=null && !viewer.getControl().isDisposed()) {
 		    viewer.setInput(input);
 		}		
 	}


### PR DESCRIPTION
If you close the outline view and then save a yml file, an error pops up that 'Save failed because widget is disposed' (or something like that).

This is a tiny change that avoids the error by checking for disposed widget before calling 'setInput'.