### PR TITLE
Some additions to root pom, to help with Release build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,17 +18,27 @@
      <id>indigo</id>
      <layout>p2</layout>
      <url>http://download.eclipse.org/releases/indigo</url>
-   </repository>	
+   </repository>    
    <repository>
      <id>orbit</id>
      <layout>p2</layout>
      <url>http://download.eclipse.org/tools/orbit/downloads/drops/R20150124073747/repository/</url>
-   </repository>	
+   </repository>    
   </repositories>
 
   <properties>
     <tycho-version>0.22.0</tycho-version>
+    <p2.qualifier>SNAPSHOT</p2.qualifier>
   </properties>
+  
+  <profiles>
+    <profile>
+      <id>release</id>
+      <properties>
+        <p2.qualifier>RELEASE</p2.qualifier>
+      </properties>
+    </profile>
+  </profiles>
 
   <build>
     <plugins>
@@ -38,6 +48,15 @@
         <version>${tycho-version}</version>
         <extensions>true</extensions>
       </plugin>
+      <plugin>
+       <groupId>org.eclipse.tycho</groupId>
+         <artifactId>tycho-packaging-plugin</artifactId>
+           <version>${tycho-version}</version>
+           <configuration>
+             <format>yyyyMMddHHmm-'${p2.qualifier}'</format>
+             <archiveSite>true</archiveSite>
+           </configuration>
+        </plugin>
     </plugins>
   </build>
   


### PR DESCRIPTION
Changes:

1. Adds a property 'p2.qualifier' which is to be set to something like 'SNAPSHOT' or 'RELEASE'.
The default value for the property is 'SNAPSHOT'.

2. A 'release' profile is defined to set the property to 'RELEASE'. The profile is activated by adding '-Prelease' to the mvn commandline. (It is almost as easy to just set the property on the commandline: '-Dp2.qualifier=RELEASE' directly. If you prefer this then you could omit the profile definition from the pom.

3. configure packaging plugin to incorporate 'p2.qualifier' into the qualifier of all built-artefacts thereby making it easy to see whether a pluing/feature version is a release or not. 
 
4. enable 'archiveSite' option in packaging plugin. The result of that is that a zipped update site is created in 'org.dadacoalition.yedit.update/target/site_assembly.zip'. Might be convenient to upload the site somewhere for publication and/or archival. 
