### PR TITLE
#15 - remove key binding for the Format Document command

### DIFF
--- a/org.dadacoalition.yedit/plugin.xml
+++ b/org.dadacoalition.yedit/plugin.xml
@@ -151,12 +151,13 @@
             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
             sequence="M1+/">
       </key>
-      <key
+      <!--#13  source format removes all comments -->
+      <!--<key
             commandId="org.dadacoalition.yedit.command.formatDocument"
             contextId="org.dadacoalition.yedit.yeditScope"
             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
             sequence="M1+M2+F">
-      </key>
+      </key>-->
    </extension>
    <extension
          point="org.eclipse.ui.contexts">


### PR DESCRIPTION
Source format removes all comments, fixing it is not an easy thing to do. As a temporary measure, we remove the key binding to avoid unexpected information loss for the users.
The command is still available from the context menu:
<img width="412" alt="screen shot 2016-10-12 at 3 26 23 pm" src="https://cloud.githubusercontent.com/assets/644582/19324559/44a0a47c-9090-11e6-9510-70414d9058fe.png">

See comments to #15 for details.
