### PR TITLE
#40 Syntax highlighting not working correctly with non ascii text

### DIFF
--- a/org.dadacoalition.yedit.test/scanner-test-files/key-accented-chars-tests.yaml
+++ b/org.dadacoalition.yedit.test/scanner-test-files/key-accented-chars-tests.yaml
@@ -1,0 +1,41 @@
+---
+name: Parsing keys with accented characters
+contentFile: key-accented-chars.yaml
+rangeLength: -1
+startOffset: 0
+expectedTokens:
+
+  - type: DOCUMENT_START
+  
+  # Poèmes
+  - type: WHITESPACE
+  - type: KEY
+  
+  # Poème1
+  - type: WHITESPACE
+  - type: KEY
+ 
+  - type: WHITESPACE
+  - type: KEY
+  - type: WHITESPACE
+  - type: SCALAR
+  
+  - type: WHITESPACE
+  - type: KEY
+  - type: WHITESPACE
+  - type: SCALAR
+
+  - type: WHITESPACE
+  - type: KEY
+  - type: WHITESPACE
+  - type: SCALAR
+
+  # Prop2
+  - type: WHITESPACE
+  - type: KEY
+ 
+  - type: WHITESPACE
+  - type: KEY
+  - type: WHITESPACE
+  - type: SCALAR
+

--- a/org.dadacoalition.yedit.test/scanner-test-files/key-accented-chars.yaml
+++ b/org.dadacoalition.yedit.test/scanner-test-files/key-accented-chars.yaml
@@ -1,0 +1,9 @@
+---
+Poèmes:
+  Poème1:
+    MaîtreCorbeau: value
+    SurUnArbrePerché: value
+    î: value
+  Prop2:
+    grünen: value
+

--- a/org.dadacoalition.yedit.test/src/org/dadacoalition/yedit/test/scanner/YAMLScannerTest.java
+++ b/org.dadacoalition.yedit.test/src/org/dadacoalition/yedit/test/scanner/YAMLScannerTest.java
@@ -66,7 +66,8 @@ public class YAMLScannerTest {
 				"comment-tests.yaml",
 				"tag-tests.yaml",
 				"scalar-test.yaml",
-				"key-tests.yaml"
+				"key-tests.yaml",
+				"key-accented-chars-tests.yaml"
 		};
 
 		Collection<Object[]> testCases = new ArrayList<Object[]>();

--- a/org.dadacoalition.yedit/src/org/dadacoalition/yedit/editor/scanner/KeyRule.java
+++ b/org.dadacoalition.yedit/src/org/dadacoalition/yedit/editor/scanner/KeyRule.java
@@ -23,12 +23,12 @@ import org.eclipse.jface.text.rules.Token;
  */
 public class KeyRule implements IRule {
 
-    private IToken token;
+    private IToken token; 
     private Pattern keyPattern;
     
     public KeyRule( IToken token ){
         this.token = token;
-        keyPattern = Pattern.compile( getKeyRegex(), Pattern.DOTALL | Pattern.COMMENTS );
+        keyPattern = Pattern.compile( getKeyRegex(), Pattern.DOTALL | Pattern.COMMENTS | Pattern.UNICODE_CHARACTER_CLASS);
     }
         
     public IToken evaluate(ICharacterScanner scanner) {


### PR DESCRIPTION
Added a `UNICODE_CHARACTER_CLASS` option to the Key regex:
<img width="230" alt="screen shot 2017-03-29 at 5 59 27 pm" src="https://cloud.githubusercontent.com/assets/644582/24478609/7bb1d4f2-14a9-11e7-831a-5d91425966fd.png">

## Tests
Tests are available in `key-accented-chars.yaml`